### PR TITLE
Add meteor 0.9.4

### DIFF
--- a/meteor.rb
+++ b/meteor.rb
@@ -1,0 +1,19 @@
+require "formula"
+
+class Meteor < Formula
+  homepage "https://www.meteor.com"
+  url "https://d3sqy0vbqsdhku.cloudfront.net/packages-bootstrap/0.9.4/meteor-bootstrap-os.osx.x86_64.tar.gz", :using => :nounzip
+  sha1 "f17785713e43116d029a5358c50ecd669c9b52fb"
+  version "0.9.4"
+
+  def install
+    system "tar xvfz meteor-bootstrap-os.osx.x86_64.tar.gz"
+    system "mv .meteor meteor"
+    system "rm meteor-bootstrap-os.osx.x86_64.tar.gz"
+    prefix.install Dir["meteor/*"]
+    bin.install_symlink prefix/"meteor"
+  end
+
+  #test do
+  #end
+end


### PR DESCRIPTION
Meteor has a self-update function, [disqualifying it from the core homebrew tap](https://github.com/meteor/meteor/issues/16). See also ["We don't like tools that upgrade themselves"](https://github.com/Homebrew/homebrew/wiki/Acceptable-Formulae#user-content-we-dont-like-tools-that-upgrade-themselves) in the [Acceptable Formulae](https://github.com/Homebrew/homebrew/wiki/Acceptable-Formulae) guide.

This formula installs meteor 0.9.4 to the homebrew cellar.
