### PR TITLE
Update meteor to 1.0

### DIFF
--- a/meteor.rb
+++ b/meteor.rb
@@ -2,9 +2,9 @@ require "formula"
 
 class Meteor < Formula
   homepage "https://www.meteor.com"
-  url "https://d3sqy0vbqsdhku.cloudfront.net/packages-bootstrap/0.9.4/meteor-bootstrap-os.osx.x86_64.tar.gz", :using => :nounzip
-  sha1 "f17785713e43116d029a5358c50ecd669c9b52fb"
-  version "0.9.4"
+  url "https://d3sqy0vbqsdhku.cloudfront.net/packages-bootstrap/1.0/meteor-bootstrap-os.osx.x86_64.tar.gz", :using => :nounzip
+  sha1 "795908ab21b26e57d09e0c289b6279a125ef6e2f"
+  version "1.0"
 
   def install
     system "tar xvfz meteor-bootstrap-os.osx.x86_64.tar.gz"


### PR DESCRIPTION
Tested locally on a Mac OS X 10.10 with `brew install path/to/homebrew-tap/meteor.rb`
